### PR TITLE
fix(): specify application dependencies for OTP releases

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,7 @@ defmodule Topo.Mixfile do
   end
 
   def application do
-    [applications: [:logger]]
+    [applications: [:logger, :geo, :seg_seg, :vector]]
   end
 
   defp deps do


### PR DESCRIPTION
This PR adds needed dependencies to the mix file applications section, which helps to avoid run time errors when building an OTP release.
