### PR TITLE
Add geometry collection support for contains

### DIFF
--- a/lib/topo/contains.ex
+++ b/lib/topo/contains.ex
@@ -16,7 +16,7 @@ defmodule Topo.Contains do
           | %Geo.Polygon{}
           | %Geo.MultiPolygon{}
 
-  @spec contains?(geo_struct, geo_struct) :: boolean
+  @spec contains?(geo_struct | %Geo.GeometryCollection{}, geo_struct) :: boolean
   def contains?(%Geo.Point{} = a, %Geo.Point{} = b), do: a == b
   def contains?(%Geo.Point{} = a, %Geo.MultiPoint{} = b), do: contains_all?(a, b, Geo.Point)
   def contains?(%Geo.Point{}, _), do: false
@@ -24,6 +24,10 @@ defmodule Topo.Contains do
   def contains?(%Geo.MultiPoint{} = a, %Geo.Point{} = b), do: any_contain?(a, b, Geo.Point)
   def contains?(%Geo.MultiPoint{} = a, %Geo.MultiPoint{} = b), do: contains_all?(a, b, Geo.Point)
   def contains?(%Geo.MultiPoint{}, _), do: false
+
+  def contains?(%Geo.GeometryCollection{geometries: geometries}, b) do
+    Enum.any?(geometries, &contains?(&1, b))
+  end
 
   def contains?(%Geo.LineString{} = a, %Geo.Point{} = b) do
     cond do


### PR DESCRIPTION
## Enables contains check for `Geo.GeometryCollection`

Example:

```ex
a = %Geo.GeometryCollection{
  geometries: [
    %Geo.Polygon{
      coordinates: [
        [
          {16.5234375, 55.97379820507658},
          {10.8984375, 52.696361078274485},
          {16.5234375, 49.15296965617042},
          {25.3125, 50.51342652633956},
          {25.3125, 54.36775852406841},
          {16.5234375, 55.97379820507658}
        ]
      ],
      properties: %{},
      srid: nil
    }
  ],
  properties: %{},
  srid: nil
}

b = %Geo.Point{coordinates: {19.1343786, 51.9537505}, properties: %{}, srid: nil}

Topo.contains? a, b
true
```