### PR TITLE
Points intersect based on coordinates

### DIFF
--- a/lib/topo/intersects.ex
+++ b/lib/topo/intersects.ex
@@ -16,7 +16,8 @@ defmodule Topo.Intersects do
           | %Geo.MultiPolygon{}
 
   @spec intersects?(geo_struct, geo_struct) :: boolean
-  def intersects?(%Geo.Point{} = a, %Geo.Point{} = b), do: a == b
+  def intersects?(%Geo.Point{coordinates: c}, %Geo.Point{coordinates: c}), do: true
+  def intersects?(%Geo.Point{}, %Geo.Point{}), do: false
   def intersects?(%Geo.Point{} = a, %Geo.MultiPoint{} = b), do: intersects_any?(a, b, Geo.Point)
 
   def intersects?(%Geo.Point{coordinates: a}, %Geo.LineString{coordinates: b}),

--- a/test/point_point_test.exs
+++ b/test/point_point_test.exs
@@ -7,6 +7,10 @@ defmodule PointPointTest do
     assert Topo.intersects?(@point, @point)
   end
 
+  test "point should intersect in coordinates only" do
+    assert Topo.intersects?(@point, %{@point | properties: %{foo: :bar}})
+  end
+
   test "point should not be disjoint from itself" do
     refute Topo.disjoint?(@point, @point)
   end


### PR DESCRIPTION
Determining if 2 points are intersecting is done now based on coordinates only:

Previously:

```elixir
Topo.intersects?(%Geo.Point{coordinates: {1, 5}}, %Geo.Point{coordinates: {1, 5}, properties: %{foo: :bar}})
> true
```

