### PR TITLE
Fix matching on +0.0 from Erlang/OTP 27+ warnings

### DIFF
--- a/lib/topo/point_ring.ex
+++ b/lib/topo/point_ring.ex
@@ -38,8 +38,7 @@ defmodule Topo.PointRing do
     count_crossing(ring, {0, 0})
   end
 
-  defp count_crossing([{0.0, 0.0} | _], _), do: {:vertex, :vertex}
-  defp count_crossing([{0, 0} | _], _), do: {:vertex, :vertex}
+  defp count_crossing([{x, y} | _], _) when x == 0 and y == 0, do: {:vertex, :vertex}
 
   defp count_crossing([a, b | rest], crosses) do
     crosses = calc_crosses(a, b, crosses)


### PR DESCRIPTION
The changes fix the following warnings:

```elixir
warning: pattern matching on 0.0 is equivalent to matching only on +0.0 from Erlang/OTP 27+. Instead you must match on +0.0 or -0.0
└─ lib/topo/point_ring.ex: Topo.PointRing.count_crossing/2

warning: pattern matching on 0.0 is equivalent to matching only on +0.0 from Erlang/OTP 27+. Instead you must match on +0.0 or -0.0
└─ lib/topo/point_ring.ex: Topo.PointRing.count_crossing/2
```

The suggested way to fix them is discussed here: https://elixirforum.com/t/inconsistency-with-compiler-warnings-upgrading-to-1-17/64209/4

> regardless of the OTP version:
> -    if you want to match on any zero, use `x == 0`

